### PR TITLE
[EDIFICE] Track the number of multimedia resources used in resources produced with the new rich editor

### DIFF
--- a/src/main/resources/schema/events/stats.json
+++ b/src/main/resources/schema/events/stats.json
@@ -1916,5 +1916,25 @@
             {"client_name" : "VARCHAR(32)"},
             {"client_version" : "VARCHAR(32)"}
         ]
+    },{
+        "table" : "events.editor_content_events" ,
+        "attributes" : [ 
+            {"profile" : "VARCHAR(9)"},
+            {"module" : "VARCHAR(64)"},
+            {"event_type" : "VARCHAR(16)"},
+            {"ua": "VARCHAR(256)"},
+            {"device_type" : "VARCHAR(32)"},
+            {"platform_id" : "VARCHAR(36)"},
+            {"user_id" : "VARCHAR(36)"},
+            {"ip": "inet"},
+            {"nb_images": "INTEGER"},
+            {"nb_sounds": "INTEGER"},
+            {"nb_videos": "INTEGER"},
+            {"nb_embedded": "INTEGER"},
+            {"nb_formulae": "INTEGER"},
+            {"nb_attachments": "INTEGER"},
+            {"nb_external_links": "INTEGER"},
+            {"nb_internal_links": "INTEGER"}
+        ]
     }
 ]


### PR DESCRIPTION
# Description

Ajout de la table editor_content_events permettant d'enregsitrer le décompte des ressources multimédias dans le contenu produit par le nouvel éditeur.

Les données remontées sont décrites [ici](https://edifice-community.atlassian.net/wiki/spaces/ODE/pages/3844505685/Cadrage+technique+-+data+Editeur#Marquage-de-l%E2%80%99utilisation-des-contenus-multim%C3%A9dia).

# Ticket

[WB-2604](https://edifice-community.atlassian.net/browse/WB-2604)

[WB-2604]: https://edifice-community.atlassian.net/browse/WB-2604?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ